### PR TITLE
fix: prevent crash due to empty dependencies in root package.json

### DIFF
--- a/projects/add-nx-to-monorepo/src/add-nx-to-monorepo.ts
+++ b/projects/add-nx-to-monorepo/src/add-nx-to-monorepo.ts
@@ -287,6 +287,7 @@ function getTsConfigFileName(repoRoot: string) {
 // add dependencies
 function addDepsToPackageJson(repoRoot: string, useCloud: boolean) {
   const json = readJsonFile(repoRoot, `package.json`);
+  if (!json.dependencies) json.dependencies = {};
   if (!json.devDependencies) json.devDependencies = {};
   json.devDependencies['@nrwl/workspace'] = 'latest';
   json.devDependencies['@nrwl/cli'] = 'latest';


### PR DESCRIPTION
I experienced a crash with my yarn workspaces monorepo that I just tried to migrate to nx.
I had no dependencies in the root package.json, only dev-dependencies.
I guess this fixes the issue.