### PR TITLE
fix: Output paths in build target, require to import, e2e fixes

### DIFF
--- a/projects/cra-to-nx/LICENSE
+++ b/projects/cra-to-nx/LICENSE
@@ -1,6 +1,6 @@
 (The MIT License)
 
-Copyright (c) 2017-2020 Narwhal Technologies Inc.
+Copyright (c) 2017-2021 Narwhal Technologies Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/projects/cra-to-nx/jest.config.js
+++ b/projects/cra-to-nx/jest.config.js
@@ -10,5 +10,5 @@ module.exports = {
     '^.+\\.[tj]sx?$': 'ts-jest',
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-  coverageDirectory: '../../coverage/packages/cra-to-nx',
+  coverageDirectory: '../../coverage/projects/cra-to-nx',
 };

--- a/projects/cra-to-nx/src/lib/add-build-path-to-workspace-json.ts
+++ b/projects/cra-to-nx/src/lib/add-build-path-to-workspace-json.ts
@@ -1,0 +1,10 @@
+import * as fs from 'fs';
+export function addBuildPathToWorkspaceJson(appName: string) {
+  const data = fs.readFileSync(`workspace.json`);
+  const json = JSON.parse(data.toString());
+  json.projects[
+    `${appName}`
+  ].targets.build.options.outputPath = `dist/apps/${appName}`;
+  json.projects[`${appName}`].targets.build.outputs = ['{options.outputPath}'];
+  fs.writeFileSync(`workspace.json`, JSON.stringify(json, null, 2));
+}

--- a/projects/cra-to-nx/src/lib/cra-to-nx.ts
+++ b/projects/cra-to-nx/src/lib/cra-to-nx.ts
@@ -4,8 +4,10 @@ import { output } from '@nrwl/workspace/src/utilities/output';
 import { execSync } from 'child_process';
 
 import { statSync } from 'fs-extra';
+import { addBuildPathToWorkspaceJson } from './add-build-path-to-workspace-json';
 import { addCRACommandsToWorkspaceJson } from './add-cra-commands-to-nx';
 import { checkForUncommittedChanges } from './check-for-uncommitted-changes';
+import { fixE2eTesting } from './fix-e2e-testing';
 import { readNameFromPackageJson } from './read-name-from-package-json';
 import { setupTsConfig } from './tsconfig-setup';
 import { writeConfigOverrides } from './write-config-overrides';
@@ -77,6 +79,8 @@ export async function createNxWorkspaceForReact() {
 
   addCRACommandsToWorkspaceJson(reactAppName, appIsJs);
 
+  addBuildPathToWorkspaceJson(reactAppName);
+
   output.log({ title: '🧑‍🔧 Customize webpack' });
 
   writeConfigOverrides(reactAppName);
@@ -108,6 +112,10 @@ export async function createNxWorkspaceForReact() {
   output.log({ title: '📃 Setup app-specific eslint' });
 
   setupTsConfig(reactAppName);
+
+  output.log({ title: '📃 Setup e2e tests' });
+
+  fixE2eTesting(reactAppName);
 
   output.log({ title: '🙂 Please be patient, one final step remaining!' });
 

--- a/projects/cra-to-nx/src/lib/fix-e2e-testing.ts
+++ b/projects/cra-to-nx/src/lib/fix-e2e-testing.ts
@@ -1,0 +1,46 @@
+import { fileExists } from '@nrwl/workspace/src/utilities/fileutils';
+import * as fs from 'fs';
+
+export function fixE2eTesting(appName: string) {
+  const data = fs.readFileSync(`workspace.json`);
+  const json = JSON.parse(data.toString());
+  json.projects[`${appName}-e2e`].targets.e2e = {
+    executor: '@nrwl/workspace:run-commands',
+    options: {
+      commands: [`nx serve ${appName}`, `nx e2e-run-when-ready ${appName}-e2e`],
+    },
+  };
+  json.projects[`${appName}-e2e`].targets['e2e-run'] = {
+    executor: '@nrwl/cypress:cypress',
+    options: {
+      cypressConfig: `apps/${appName}-e2e/cypress.json`,
+      tsConfig: `apps/${appName}-e2e/tsconfig.e2e.json`,
+      baseUrl: 'http://localhost:3000',
+    },
+    configurations: {
+      production: { devServerTarget: `${appName}:serve:production` },
+    },
+  };
+  json.projects[`${appName}-e2e`].targets['e2e-run-when-ready'] = {
+    executor: '@nrwl/workspace:run-commands',
+    options: {
+      commands: [`nx e2e-run ${appName}-e2e`],
+      readyWhen: 'http://localhost:3000',
+    },
+  };
+  fs.writeFileSync(`workspace.json`, JSON.stringify(json, null, 2));
+
+  if (fileExists(`apps/${appName}-e2e/src/integration/app.spec.ts`)) {
+    const integrationE2eTest = `
+      describe('${appName}', () => {
+        beforeEach(() => cy.visit('/'));
+        it('should contain a body', () => {
+          cy.get('body').should('exist');
+        });
+      });`;
+    fs.writeFileSync(
+      `apps/${appName}-e2e/src/integration/app.spec.ts`,
+      integrationE2eTest
+    );
+  }
+}

--- a/projects/cra-to-nx/src/lib/read-name-from-package-json.ts
+++ b/projects/cra-to-nx/src/lib/read-name-from-package-json.ts
@@ -1,6 +1,5 @@
 import { fileExists } from '@nrwl/workspace/src/utilities/fileutils';
-
-const fs = require('fs');
+import * as fs from 'fs';
 
 export function readNameFromPackageJson(): string {
   let appName = 'webapp';

--- a/projects/cra-to-nx/src/lib/tsconfig-setup.ts
+++ b/projects/cra-to-nx/src/lib/tsconfig-setup.ts
@@ -1,6 +1,5 @@
 import { fileExists } from '@nrwl/workspace/src/utilities/fileutils';
-
-const fs = require('fs');
+import * as fs from 'fs';
 
 const defaultTsConfig = {
   extends: '../../tsconfig.base.json',

--- a/projects/cra-to-nx/src/lib/write-config-overrides.ts
+++ b/projects/cra-to-nx/src/lib/write-config-overrides.ts
@@ -1,4 +1,4 @@
-const fs = require('fs');
+import * as fs from 'fs';
 
 export function writeConfigOverrides(appName: string) {
   const configOverride = `


### PR DESCRIPTION
Some fixes to the cra-to-nx package:
1. wrong paths
2. add output paths in generated workspace
3. Fixed e2e test issues