### PR TITLE
fix: add projectType instead of type gen workspace

### DIFF
--- a/projects/add-nx-to-monorepo/src/add-nx-to-monorepo.ts
+++ b/projects/add-nx-to-monorepo/src/add-nx-to-monorepo.ts
@@ -178,7 +178,7 @@ function createWorkspaceJsonFile(repoRoot: string, pds: ProjectDesc[]) {
   };
 
   pds.forEach((f) => {
-    res.projects[f.name] = { root: normalizePath(f.dir), type: 'library' };
+    res.projects[f.name] = { root: normalizePath(f.dir), projectType: 'library' };
   });
 
   fs.writeFileSync(`${repoRoot}/workspace.json`, JSON.stringify(res, null, 2));


### PR DESCRIPTION
While using this script on a project, I noticed the generated `workspace.json` file uses `type` instead of `projectType`. This pull request should fix that.