### PR TITLE
fix: don't die if CRA app has no "README.md" file

### DIFF
--- a/projects/cra-to-nx/src/lib/cra-to-nx.ts
+++ b/projects/cra-to-nx/src/lib/cra-to-nx.ts
@@ -67,8 +67,7 @@ export async function createNxWorkspaceForReact() {
 
   output.log({ title: '🚚 Moving your React app in your new Nx workspace' });
 
-  const filesToMove = [
-    'README.md',
+  const requiredCraFiles = [
     'package.json',
     'src',
     'public',
@@ -76,11 +75,23 @@ export async function createNxWorkspaceForReact() {
     packageManager === 'yarn' ? 'yarn.lock' : null,
     packageManager === 'pnpm' ? 'pnpm-lock.yaml' : null,
     packageManager === 'npm' ? 'package-lock.json' : null,
-  ].filter(Boolean);
+  ];
 
-  filesToMove.forEach((f) =>
-    moveSync(f, `temp-workspace/apps/${reactAppName}/${f}`, { overwrite: true })
-  );
+  const optionalCraFiles = [
+    'README.md',
+  ];
+
+  const filesToMove = [...requiredCraFiles, ...optionalCraFiles].filter(Boolean);
+
+  filesToMove.forEach((f) => {
+    try {
+      moveSync(f, `temp-workspace/apps/${reactAppName}/${f}`, { overwrite: true });
+    } catch (error) {
+      if (requiredCraFiles.includes(f)) {
+        throw error;
+      }
+    }
+  });
 
   process.chdir('temp-workspace/');
 


### PR DESCRIPTION
I just discovered the `cra-to-nx` command fails if the CRA project being converted doesn't have a `README.md` file.

Had a quick look through the source files and it seems to be an easy fix. So, in a nutshell, this PR changes the following:

* splits up the `filesToMove` list into "optional" and "required"
* wraps the `moveSync` processing of each one with a `try/catch`
* only re-throws errors if the affected file is "required"

>Note: It seems the `cra-to-nx.spec.ts` file doesn't contain anything to test this, and I am unfortunately not skilled enough in that department to help write the tests.. But from my local testing, this change seems good.

---

For reference, terminal output of the error in question is as follows:

```bash
$ npx cra-to-nx
npx: installed 233 in 22.127s

>  NX  🐳 Nx initialization

npx: installed 48 in 3.369s

>  NX  Nx is creating your workspace.

  To make sure the command works reliably in all environments, and that the preset is applied correctly,
  Nx will run "npm install" several times. Please wait.


>  NX   SUCCESS  Nx has successfully created the workspace.


———————————————————————————————————————————————

UPDATE nx.json

>  NX   NOTE  Nx Cloud has been enabled

  Your workspace is currently public. Anybody with code access can view the workspace on nx.app. 
  You can connect the workspace to your Nx Cloud account at https://nx.app/orgs/workspace-setup?accessToken=ZjFkMjlhN2UtOGNiYy00Mjc0LTk2ZGItM2QxYTBkYTcyY2ZhfHJlYWQtd3JpdGU=. (You can do this later.)


———————————————————————————————————————————————


>  NX   NOTE  First time using Nx? Check out this interactive Nx tutorial.

  https://nx.dev/react/tutorial/01-create-application
  
  Prefer watching videos? Check out this free Nx course on Egghead.io.
  https://egghead.io/playlists/scale-react-development-with-nx-4038


>  NX  👋 Welcome to Nx!


>  NX  🧹 Clearing unused files


>  NX  🚚 Moving your React app in your new Nx workspace

Error: ENOENT: no such file or directory, stat 'README.md'
    at Object.statSync (fs.js:1086:3)
    at Object.statSync (/home/zalithka/.npm/_npx/57896/lib/node_modules/cra-to-nx/node_modules/graceful-fs/polyfills.js:311:34)
    at statSync (/home/zalithka/.npm/_npx/57896/lib/node_modules/cra-to-nx/node_modules/fs-extra/lib/util/stat.js:10:52)
    at getStatsSync (/home/zalithka/.npm/_npx/57896/lib/node_modules/cra-to-nx/node_modules/fs-extra/lib/util/stat.js:24:19)
    at Object.checkPathsSync (/home/zalithka/.npm/_npx/57896/lib/node_modules/cra-to-nx/node_modules/fs-extra/lib/util/stat.js:49:33)
    at Object.moveSync (/home/zalithka/.npm/_npx/57896/lib/node_modules/cra-to-nx/node_modules/fs-extra/lib/move-sync/move-sync.js:14:28)
    at /home/zalithka/.npm/_npx/57896/lib/node_modules/cra-to-nx/src/lib/cra-to-nx.js:64:47
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/home/zalithka/.npm/_npx/57896/lib/node_modules/cra-to-nx/src/lib/cra-to-nx.js:64:21)
    at Generator.next (<anonymous>) {
  errno: -2,
  syscall: 'stat',
  code: 'ENOENT',
  path: 'README.md'
}
```