### PR TITLE
fix(add-nx-to-monorepo): should work with Nx 13+

### DIFF
--- a/projects/add-nx-to-monorepo/src/add-nx-to-monorepo.ts
+++ b/projects/add-nx-to-monorepo/src/add-nx-to-monorepo.ts
@@ -220,7 +220,6 @@ function createNxJsonFile(repoRoot: string, pds: ProjectDesc[]) {
         {target: 'package', projects: 'dependencies'}
       ]
     },
-    projects: {},
     affected: {
       defaultBase: deduceDefaultBase()
     },


### PR DESCRIPTION
Running `npx add-nx-to-monorepo` should generate an nx.json file that is compatible with v13

Fixes #29 