### PR TITLE
chore: disable importHelpers in tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,14 +43,14 @@
     "dotenv": "6.2.0",
     "eslint": "7.10.0",
     "eslint-config-prettier": "6.0.0",
+    "ignore": "^5.0.4",
     "jest": "26.2.2",
     "prettier": "2.2.1",
+    "strip-json-comments": "^3.1.1",
     "ts-jest": "26.4.0",
     "ts-node": "9.1.1",
     "tslint": "6.1.3",
     "typescript": "4.0.5",
-    "ignore": "^5.0.4",
-    "strip-json-comments": "^3.1.1",
     "yargs-parser": "^20.0.0"
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,7 +7,6 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "importHelpers": true,
     "target": "es2015",
     "module": "esnext",
     "typeRoots": ["node_modules/@types"],


### PR DESCRIPTION
As this is a one-off script rather than a dependency, importHelpers doesn't bring a lot of value to the users.

This commit also fixes #28 as it no longer depends on `tslib`.

# Side-note

I was initially going to PR with just adding tslib to the dependencies but I changed my mind because `importHelpers` is usually used for saving up bundle size, which, in this specific case, isn't really an issue since it won't be included in the bundle of users and the size of the packages aren't that huge.