### PR TITLE
fix(make-angular-cli-faster): fix renamed preserve-angular-cli-layout flag

### DIFF
--- a/projects/make-angular-cli-faster/src/make-angular-cli-faster.ts
+++ b/projects/make-angular-cli-faster/src/make-angular-cli-faster.ts
@@ -63,7 +63,7 @@ async function main() {
   addDependency(`@nrwl/tao@${version}`);
   addDependency(`@nrwl/cli@${version}`);
   addDependency(`@nrwl/workspace@${version}`);
-  execSync(`nx g @nrwl/workspace:ng-add --preserveAngularCLILayout`, {
+  execSync(`nx g @nrwl/workspace:ng-add --preserve-angular-cli-layout`, {
     stdio: [0, 1, 2],
   });
 


### PR DESCRIPTION
The `preserveAngularCLILayout` flag was renamed to `preserve-angular-cli-layout` in the `@nrwl/workspace:ng-add` generator.