### PR TITLE
feat(add-nx-to-monorepo): adjust messages after disabling source code…

### DIFF
--- a/projects/add-nx-to-monorepo/src/add-nx-to-monorepo.ts
+++ b/projects/add-nx-to-monorepo/src/add-nx-to-monorepo.ts
@@ -24,7 +24,7 @@ export async function addNxToMonorepo() {
   const useCloud = await askAboutNxCloud();
 
   output.log({
-    title: `🧑‍🔧 Analyzing the source code and creating configuration files`,
+    title: `🧑‍🔧 Analyzing the source code and creating configuration file`,
   });
 
   const packageJsonFiles = allProjectPackageJsonFiles(repoRoot);
@@ -346,12 +346,14 @@ function printFinalMessage(repoRoot) {
   output.success({
     title: `🎉 Done!`,
     bodyLines: [
-      `- Computation caching and code change analysis are enabled.`,
+      `- Enabled Computation caching!`,
       `- Run "${
         getPackageManagerCommand(repoRoot).exec
-      } nx run-many --target=build --all --parallel" to run the build script for every project in the monorepo.`,
+      } nx run-many --target=build --all" to run the build script for every project in the monorepo.`,
       `- Run it again to replay the cached computation.`,
-      `- Run "nx dep-graph" to see the structure of the monorepo.`,
+      `- Run "${
+        getPackageManagerCommand(repoRoot).exec
+      } nx graph" to see the structure of the monorepo.`,
       `- Learn more at https://nx.dev/migration/adding-to-monorepo`,
     ],
   });


### PR DESCRIPTION
… analysis

Source code analysis is off now. We don't need that message.
We don't need the parallel flag, since it's enabled by default.
We only generate 1 configuration file, `nx.json`.
`nx graph` is the recommended command.