### PR TITLE
feat: change nx cloud default to yes

### DIFF
--- a/projects/add-nx-to-monorepo/src/add-nx-to-monorepo.ts
+++ b/projects/add-nx-to-monorepo/src/add-nx-to-monorepo.ts
@@ -70,7 +70,7 @@ async function askAboutNxCloud() {
             name: 'No',
           },
         ],
-        default: 'no',
+        default: 'yes',
       },
     ])
     .then((a: { NxCloud: 'yes' | 'no' }) => a.NxCloud === 'yes');

--- a/projects/make-angular-cli-faster/src/make-angular-cli-faster.ts
+++ b/projects/make-angular-cli-faster/src/make-angular-cli-faster.ts
@@ -48,7 +48,7 @@ function addNxCloud() {
             name: 'No  [Only use local computation cache]',
           },
         ],
-        default: 'no',
+        default: 'yes',
       },
     ])
     .then((a: { NxCloud: 'yes' | 'no' }) => a.NxCloud === 'yes');


### PR DESCRIPTION
Changed default value of the Nx Cloud prompt to `yes` for the `make-angular-cli-faster` and `add-nx-to-monorepo` packages.